### PR TITLE
Fixes broken event creation

### DIFF
--- a/personservice/src/main/java/com/sap/demo/applicationconnector/util/ApplicationConnectorRestTemplateBuilder.java
+++ b/personservice/src/main/java/com/sap/demo/applicationconnector/util/ApplicationConnectorRestTemplateBuilder.java
@@ -52,7 +52,7 @@ public class ApplicationConnectorRestTemplateBuilder {
 		String baseUri = connection.getEventsUrl().toString();
 
 		RestTemplateBuilder builder = getRestTemplateBuilder(connection);
-		return builder.rootUri(baseUri).build();
+		return builder.rootUri(baseUri).additionalInterceptors(new RestTemplateUrlTrailingSlashRemover()).build();
 	}
 
 	// Returns a RestTemplate where the baseUrl is set to the metadata URL of the


### PR DESCRIPTION
The requests to the /events endpoint fail in Kyma 1.1 due to trailing slashes. I fixed it using the interceptor we implemented recently.