### PR TITLE
Lambda log level change not getting applied locally

### DIFF
--- a/personservice/Lambda/.env
+++ b/personservice/Lambda/.env
@@ -1,2 +1,2 @@
 GATEWAY_URL=https://personservice.personsvc-poc-6.cluster.extend.sap.cx
-APPLICATION_LOG_LEVEL=info
+application_log_level=info


### PR DESCRIPTION
Changing `APPLICATION_LOG_LEVEL` to `debug` on `.env` file wasn't having effect on the log level locally. Changing it to lower case in order to match how it was referenced in the code and in the readme picture corrected the problem.

```GATEWAY_URL = https://personservice.kyma.local
Example app listening on port 3000!
Log level 'debug'
{"headers":{"host":"localhost:3000","connection":"keep-alive ...